### PR TITLE
PQB-67 Added Tooltip to Note Types

### DIFF
--- a/TSX/Widget/NoteWindow.tsx
+++ b/TSX/Widget/NoteWindow.tsx
@@ -188,6 +188,7 @@ const NoteWidget: EventWidget.IWidget<ISetting> = {
                                         return u;
                                     })
                                 }}
+                                ShowToolTip={true}
                             />
                             <Select<OpenXDA.Types.NoteType>
                                 Record={noteType}


### PR DESCRIPTION
Issues Adressed: PQB-67

This adds the `ShowToolTip ` to the `MultiSelect` showing the Note Types.

Testing: 
(1) Pick any event
(2) Find the Notes Widget and select any number of types.
(3) Hover over Types dropdown and make sure a Tooltip appears listing the selected Types
