### PR TITLE
use uri to parse to not cause issues with trailing slash

### DIFF
--- a/API/Visualizations/PQIHealthController.cs
+++ b/API/Visualizations/PQIHealthController.cs
@@ -60,7 +60,8 @@ namespace Widgets.API.Visualizations
 
             void ConfigureRequest(HttpRequestMessage request)
             {
-                request.RequestUri = new Uri(postData["Site"] + "/" + endPoint + queryString);
+                Uri baseUri = new Uri(postData["Site"].ToString());
+                request.RequestUri = new Uri(baseUri, endPoint + queryString);
                 MediaTypeWithQualityHeaderValue acceptHeader = new MediaTypeWithQualityHeaderValue("application/json");
                 request.Headers.Accept.Add(acceptHeader);
             }


### PR DESCRIPTION
Update to fix issue of where if there is a trailing slash in the uri specified, this endpoint may fail to work.

JIRA Ticket(s)
Ticket: [DIG-28](https://gridprotectionalliance.atlassian.net/browse/DIG-28)

No Related PRs

[DIG-28]: https://gridprotectionalliance.atlassian.net/browse/DIG-28?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ